### PR TITLE
add workflow to submit talks

### DIFF
--- a/.github/workflows/content.yml
+++ b/.github/workflows/content.yml
@@ -1,0 +1,40 @@
+name: Parse Issues
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  content:
+    if: contains(github.event.issue.labels.*.name, 'proposal')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+    - name: Show event payload
+      run: |
+        echo $GITHUB_REPOSITORY
+        echo $GITHUB_EVENT_PATH
+        ./scripts/create-content/main.py $GITHUB_EVENT_PATH
+        git status
+        git add -A
+    - name: Set issue number
+      id: issue-number
+      run: |
+        number=$(jq -r ".issue.number" $GITHUB_EVENT_PATH)
+        echo ::set-output name=number::$number
+    - name: Set issue author
+      id: issue-author
+      run: |
+        author=$(jq -r ".issue.user.login" $GITHUB_EVENT_PATH)
+        echo ::set-output name=author::$author
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v3 
+      with:
+        branch: "content/update-${{ steps.issue-number.outputs.number }}"
+        commit-message: "[automated change] Closes #${{ steps.issue-number.outputs.number }}"
+        title: "Talk proposed by ${{ steps.issue-author.outputs.author }}"
+        body: "Talk proposed by @${{ steps.issue-author.outputs.author }}\n\nRefs #${{ steps.issue-number.outputs.number }}"
+        delete-branch: true

--- a/.github/workflows/python-scripts.yml
+++ b/.github/workflows/python-scripts.yml
@@ -1,0 +1,37 @@
+name: Python Scripts
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'scripts/**'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'scripts/**'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 scripts/ --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 scripts/ --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test create-content script
+      run: |
+        cd $GITHUB_WORKSPACE/scripts/create-content/
+        pytest -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,178 @@
+
+# Created by https://www.toptal.com/developers/gitignore/api/python,vim,venv
+# Edit at https://www.toptal.com/developers/gitignore?templates=python,vim,venv
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+pytestdebug.log
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+doc/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+pythonenv*
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# profiling data
+.prof
+
+### venv ###
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+[Bb]in
+[Ii]nclude
+[Ll]ib
+[Ll]ib64
+[Ll]ocal
+[Ss]cripts
+pyvenv.cfg
+pip-selfcheck.json
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+# End of https://www.toptal.com/developers/gitignore/api/python,vim,venv

--- a/scripts/create-content/main.py
+++ b/scripts/create-content/main.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+#
+# Originally:
+# Parse Github issues created using this template:
+# https://github.com/sre-paris/reliability.re/blob/main/.github/ISSUE_TEMPLATE/new-content.md
+
+import sys
+import json
+import http.client
+
+
+def slugify(date, title):
+    """Very naive slugify function."""
+    slug = title.lower()
+    # Remove stranger chars
+    slug = slug.replace("'", "")
+    slug = slug.replace(":", "")
+    slug = slug.replace("’", "")
+    slug = slug.replace("?", "")
+    slug = slug.replace("%", "")
+    slug = slug.replace("—", "")
+    slug = slug.replace("…", "")
+
+    # Remove leading, trailing and duplicated whitespaces
+    slug = " ".join(slug.split())
+    # Replace spaces with "-"'s for cleaner URLs
+    slug = slug.replace(" ", "-")
+
+    date = date[:10]
+    return f"cfp/{date}-{slug}.md"
+
+def get_twitter_username(username):
+    """Get Twitter username from Github profile information."""
+    conn = http.client.HTTPSConnection("api.github.com")
+    headers = {
+        "Content-type": "application/json",
+        "User-Agent": "sre-paris",
+    }
+    conn.request("GET", "/users/%s" % username, headers=headers)
+    response = conn.getresponse()
+    data = json.loads(response.read().decode())
+    return data["twitter_username"]
+
+def main(filename):
+    with open(filename, "r") as f:
+        data = json.load(f)
+
+    content = "---\n"
+
+    title = data["issue"]["title"]
+    content += 'title: "%s"\n' % title
+
+    created_at = data["issue"]["created_at"]
+    content += "date: %s\n" % created_at
+
+    github_username = data["issue"]["user"]["login"]
+    content += "github_username: %s\n" % github_username
+
+    twitter_username = get_twitter_username(github_username)
+    if twitter_username:
+        content += "twitter_username: %s\n" % twitter_username
+
+    body = data["issue"]["body"]
+    content += "---\n%s\n" % body
+
+    post_filename = slugify(created_at, title)
+    print(post_filename)
+    print(content)
+
+    with open(post_filename, "w+") as f:
+        print(content, file=f)
+
+if __name__ == "__main__":
+    filename = sys.argv[1]
+    main(filename)

--- a/scripts/create-content/test_main.py
+++ b/scripts/create-content/test_main.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+import unittest
+from unittest import mock
+from io import StringIO
+
+from main import main
+from main import slugify
+
+
+class TestSlugyFunction(unittest.TestCase):
+    def test_happy_path(self):
+        date = "2020-10-02"
+        title = "This is a title"
+        expected = "cfp/2020-10-02-this-is-a-title.md"
+        output = slugify(date, title)
+        self.assertEqual(expected, output)
+
+    def test_single_quote(self):
+        date = "2020-10-02"
+        title = "It's a title"
+        expected = "cfp/2020-10-02-its-a-title.md"
+        output = slugify(date, title)
+        self.assertEqual(expected, output)
+
+    def test_single_quote_utf(self):
+        date = "2020-10-02"
+        title = "Under Deconstruction: The State of Shopify’s Monolith"
+        expected = "cfp/2020-10-02-under-deconstruction-the-state-of-shopifys-monolith.md"
+        output = slugify(date, title)
+        self.assertEqual(expected, output)
+
+    def test_question_mark(self):
+        date = "2020-10-02"
+        title = "how they test ?"
+        expected = "cfp/2020-10-02-how-they-test.md"
+        output = slugify(date, title)
+        self.assertEqual(expected, output)
+
+    def test_percent_sign(self):
+        date = "2020-10-02"
+        title = "Why is 100% reliability the wrong target?"
+        expected = "cfp/2020-10-02-why-is-100-reliability-the-wrong-target.md"
+        output = slugify(date, title)
+        self.assertEqual(expected, output)
+
+    def test_em_dash_and_ellipsis(self):
+        date = "2020-10-02"
+        title = "SLO — From Nothing to… Production"
+        expected = "cfp/2020-10-02-slo-from-nothing-to-production.md"
+        output = slugify(date, title)
+        self.assertEqual(expected, output)
+
+
+class TestMain(unittest.TestCase):
+    @mock.patch("sys.stdout", new_callable=StringIO)
+    def test_parse_issue(self, mock_stdout):
+        json_data = r"""
+            {
+                "issue": {
+                    "title": "My awesome talk",
+                    "created_at": "2021-03-08T18:10:04Z",
+                    "user": {
+                        "login": "tormath1"
+                    },
+                    "body": "__author name__: My name\r\n\r\n__author bio__: My bio\r\n\r\n__expected time__ :\r\n\r\n- [x] lightning talk (~ 5 min)\r\n- [ ] 15 min\r\n\r\n__language__:\r\n\r\n- [x] :fr:\r\n- [ ] :uk:\r\n\r\n__abstract__: in this talk, we will talk about linux\r\n"
+                }
+            }"""
+        expected = """cfp/2021-03-08-my-awesome-talk.md
+---
+title: "My awesome talk"
+date: 2021-03-08T18:10:04Z
+github_username: tormath1
+twitter_username: tormath1
+---
+__author name__: My name\r
+\r
+__author bio__: My bio\r
+\r
+__expected time__ :\r
+\r
+- [x] lightning talk (~ 5 min)\r
+- [ ] 15 min\r
+\r
+__language__:\r
+\r
+- [x] :fr:\r
+- [ ] :uk:\r
+\r
+__abstract__: in this talk, we will talk about linux\r
+
+
+"""
+        with mock.patch("main.open", mock.mock_open(read_data=json_data)):
+            main(None)
+            self.assertEqual(expected, mock_stdout.getvalue())
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Following discussions on Telegram and in the linked issue, we add a GH workflow in order to ease talk submission for the next meetups (user workflow is described in the issue).

A running example can be found on my fork in the following issue: https://github.com/tormath1/meetups/issues/6. You can ofc try it by yourself.

Some initial feedback:

- Finally, I'm not a big fan of using checkbox for the slot time / language since it will show the issue as "incomplete"
- Python tests will never work on this repo since the action listens on `main` branch and we still have a `master` branch
- A dedicated label called "proposal" needs to be created



closes https://github.com/sre-paris/meetups/issues/12